### PR TITLE
Fixed incorrect param name.

### DIFF
--- a/smc/docs/pages/session.rst
+++ b/smc/docs/pages/session.rst
@@ -122,12 +122,12 @@ Then from launching scripts, you can do:
 	session.login()
 	session.logout()
 
-.. note:: It is possible to override the location of .smcrc by using the 'altpath' argument in
+.. note:: It is possible to override the location of .smcrc by using the 'alt_filepath' argument in
           the login constructor.
 
 .. code-block:: python
 
-   session.login(altpath='/home/somedir/test')
+   session.login(alt_filepath='/home/somedir/test')
 
 Environment Variables
 *********************


### PR DESCRIPTION
The parameter specified in the docs for specifying the path to the smcrc file is outdated. The current version uses alt_filepath rather than altpath.